### PR TITLE
Fix An argument named "name" is not expected here

### DIFF
--- a/examples/bucket/main.tf
+++ b/examples/bucket/main.tf
@@ -5,9 +5,9 @@ module "storage_buckets" {
 
   source = "../../"
 
-  name = format("testprefix-%s", each.key)
+  bucket_name = format("testprefix-%s", each.key)
 
-  storage_class     = each.value["storage_class"]
-  max_size          = each.value["max_size"]
-  enable_versioning = each.value["enable_versioning"]
+#   storage_class     = each.value["storage_class"]
+#   max_size          = each.value["max_size"]
+#   enable_versioning = each.value["enable_versioning"]
 }


### PR DESCRIPTION
Исправляет ошибку https://github.com/terraform-yacloud-modules/terraform-yandex-storage-bucket/issues/33
но появляется другая ошибка. Другую ошибку, посмотрим в другом issue.