### PR TITLE
fix does not match hashicorp/aws version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0.0"
+      version = "~> 5.91.0"
     }
   }
 }


### PR DESCRIPTION
Fix:
```
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/aws v5.98.0 does not have a package available for your current platform, linux_amd64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all platforms. Other versions of this provider may have
│ different platforms supported.

```